### PR TITLE
[Fix] SizeConverter, update regex value to allow negative values

### DIFF
--- a/src/OnTopReplica/StartupOptions/SizeConverter.cs
+++ b/src/OnTopReplica/StartupOptions/SizeConverter.cs
@@ -10,7 +10,7 @@ namespace OnTopReplica.StartupOptions {
     class SizeConverter : TypeConverter {
 
         public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) {
-            if (value != null) {
+            if(value != null) {
                 var sVal = value.ToString();
                 return StringToSize(sVal);
             }
@@ -27,26 +27,26 @@ namespace OnTopReplica.StartupOptions {
         }
 
         public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType) {
-            if (value == null)
+            if(value == null)
                 return base.ConvertTo(context, culture, value, destinationType);
 
-            if (destinationType == typeof(Size)) {
+            if(destinationType == typeof(Size)) {
                 var sVal = value.ToString();
                 return StringToSize(sVal);
             }
-            else if (destinationType == typeof(string)) {
-                if (value is Size) {
+            else if(destinationType == typeof(string)) {
+                if(value is Size) {
                     Size sValue = (Size)value;
                     return string.Format("{0}, {1}", sValue.Width, sValue.Height);
                 }
-                
+
                 return value.ToString();
             }
             else
                 return base.ConvertTo(context, culture, value, destinationType);
         }
 
-        static Regex _sizeRegex = new Regex("^\\D*(?<x>\\d*)\\s*,\\s*(?<y>\\d*)\\D*$",
+        static Regex _sizeRegex = new Regex("^[^0-9-]*(?<x>-?\\d*)\\s*,\\s*(?<y>-?\\d*)\\D*$",
             RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
 
         private Size StringToSize(string s) {
@@ -55,7 +55,7 @@ namespace OnTopReplica.StartupOptions {
             var x = match.Groups["x"];
             var y = match.Groups["y"];
 
-            if (!match.Success || !x.Success || !y.Success)
+            if(!match.Success || !x.Success || !y.Success)
                 throw new ArgumentException("Cannot convert '" + s + "' to coordinates pair.");
 
             var xVal = Int32.Parse(x.Value);


### PR DESCRIPTION
In case of multiple screens, coordinate to set position must allow negative values. This has been fixed by this small commit.