### PR TITLE
Add toggle to switch to source window with double-click

### DIFF
--- a/src/OnTopReplica/MainForm.Designer.cs
+++ b/src/OnTopReplica/MainForm.Designer.cs
@@ -62,13 +62,14 @@
             this.bottomLeftToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.bottomRightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.chromeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.restoreToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.reduceToIconToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuContextClose = new System.Windows.Forms.ToolStripMenuItem();
-            this.fullOpacityToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fullSelectWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fullOpacityToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuFullscreenContext = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.modeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuModeStandardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -94,13 +95,14 @@
             this.resizeToolStripMenuItem,
             this.dockToolStripMenuItem,
             this.chromeToolStripMenuItem,
+            this.restoreToolStripMenuItem,
             this.reduceToIconToolStripMenuItem,
             this.toolStripSeparator1,
             this.settingsToolStripMenuItem,
             this.aboutToolStripMenuItem,
             this.menuContextClose});
             this.menuContext.Name = "menuContext";
-            this.menuContext.Size = new System.Drawing.Size(187, 274);
+            this.menuContext.Size = new System.Drawing.Size(195, 318);
             this.menuContext.Opening += new System.ComponentModel.CancelEventHandler(this.Menu_opening);
             // 
             // menuContextWindows
@@ -108,7 +110,7 @@
             this.menuContextWindows.DropDown = this.menuWindows;
             this.menuContextWindows.Image = global::OnTopReplica.Properties.Resources.list;
             this.menuContextWindows.Name = "menuContextWindows";
-            this.menuContextWindows.Size = new System.Drawing.Size(186, 22);
+            this.menuContextWindows.Size = new System.Drawing.Size(194, 22);
             this.menuContextWindows.Text = global::OnTopReplica.Strings.MenuWindows;
             this.menuContextWindows.ToolTipText = global::OnTopReplica.Strings.MenuWindowsTT;
             // 
@@ -130,7 +132,7 @@
             // 
             this.switchToWindowToolStripMenuItem.Image = global::OnTopReplica.Properties.Resources.xiao_arrow;
             this.switchToWindowToolStripMenuItem.Name = "switchToWindowToolStripMenuItem";
-            this.switchToWindowToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.switchToWindowToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
             this.switchToWindowToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuSwitch;
             this.switchToWindowToolStripMenuItem.ToolTipText = global::OnTopReplica.Strings.MenuSwitchTT;
             this.switchToWindowToolStripMenuItem.Click += new System.EventHandler(this.Menu_Switch_click);
@@ -140,7 +142,7 @@
             this.selectRegionToolStripMenuItem.Enabled = false;
             this.selectRegionToolStripMenuItem.Image = global::OnTopReplica.Properties.Resources.regions;
             this.selectRegionToolStripMenuItem.Name = "selectRegionToolStripMenuItem";
-            this.selectRegionToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.selectRegionToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
             this.selectRegionToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuRegion;
             this.selectRegionToolStripMenuItem.ToolTipText = global::OnTopReplica.Strings.MenuRegionTT;
             this.selectRegionToolStripMenuItem.Click += new System.EventHandler(this.Menu_Region_click);
@@ -154,7 +156,7 @@
             this.restoreLastClonedWindowToolStripMenuItem});
             this.advancedToolStripMenuItem.Image = global::OnTopReplica.Properties.Resources.xiao_wrench;
             this.advancedToolStripMenuItem.Name = "advancedToolStripMenuItem";
-            this.advancedToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.advancedToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
             this.advancedToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuAdvanced;
             this.advancedToolStripMenuItem.DropDownOpening += new System.EventHandler(this.Menu_Advanced_opening);
             // 
@@ -198,7 +200,7 @@
             this.menuContextOpacity.DropDown = this.menuOpacity;
             this.menuContextOpacity.Image = global::OnTopReplica.Properties.Resources.window_opacity;
             this.menuContextOpacity.Name = "menuContextOpacity";
-            this.menuContextOpacity.Size = new System.Drawing.Size(186, 22);
+            this.menuContextOpacity.Size = new System.Drawing.Size(194, 22);
             this.menuContextOpacity.Text = global::OnTopReplica.Strings.MenuOpacity;
             // 
             // menuOpacity
@@ -258,7 +260,7 @@
             this.resizeToolStripMenuItem.DropDown = this.menuResize;
             this.resizeToolStripMenuItem.Enabled = false;
             this.resizeToolStripMenuItem.Name = "resizeToolStripMenuItem";
-            this.resizeToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.resizeToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
             this.resizeToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuResize;
             // 
             // menuResize
@@ -342,7 +344,7 @@
             this.bottomRightToolStripMenuItem});
             this.dockToolStripMenuItem.Image = global::OnTopReplica.Properties.Resources.pos_null;
             this.dockToolStripMenuItem.Name = "dockToolStripMenuItem";
-            this.dockToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.dockToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
             this.dockToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuPosition;
             this.dockToolStripMenuItem.ToolTipText = global::OnTopReplica.Strings.MenuPositionTT;
             this.dockToolStripMenuItem.DropDownOpening += new System.EventHandler(this.Menu_Position_Opening);
@@ -399,16 +401,24 @@
             // chromeToolStripMenuItem
             // 
             this.chromeToolStripMenuItem.Name = "chromeToolStripMenuItem";
-            this.chromeToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.chromeToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
             this.chromeToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuChrome;
             this.chromeToolStripMenuItem.ToolTipText = global::OnTopReplica.Strings.MenuChromeTT;
             this.chromeToolStripMenuItem.Click += new System.EventHandler(this.Menu_Chrome_click);
+            // 
+            // restoreToolStripMenuItem
+            // 
+            this.restoreToolStripMenuItem.Name = "restoreToolStripMenuItem";
+            this.restoreToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+            this.restoreToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuRestore;
+            this.restoreToolStripMenuItem.ToolTipText = global::OnTopReplica.Strings.MenuRestoreTT;
+            this.restoreToolStripMenuItem.Click += new System.EventHandler(this.Menu_Restore_click);
             // 
             // reduceToIconToolStripMenuItem
             // 
             this.reduceToIconToolStripMenuItem.Image = global::OnTopReplica.Properties.Resources.minimize;
             this.reduceToIconToolStripMenuItem.Name = "reduceToIconToolStripMenuItem";
-            this.reduceToIconToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.reduceToIconToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
             this.reduceToIconToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuReduce;
             this.reduceToIconToolStripMenuItem.ToolTipText = global::OnTopReplica.Strings.MenuReduceTT;
             this.reduceToIconToolStripMenuItem.Click += new System.EventHandler(this.Menu_Reduce_click);
@@ -416,12 +426,12 @@
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(183, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(191, 6);
             // 
             // settingsToolStripMenuItem
             // 
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
             this.settingsToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuSettings;
             this.settingsToolStripMenuItem.ToolTipText = global::OnTopReplica.Strings.MenuSettingsTT;
             this.settingsToolStripMenuItem.Click += new System.EventHandler(this.Menu_Settings_click);
@@ -430,7 +440,7 @@
             // 
             this.aboutToolStripMenuItem.Image = global::OnTopReplica.Properties.Resources.help;
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
             this.aboutToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuAbout;
             this.aboutToolStripMenuItem.ToolTipText = global::OnTopReplica.Strings.MenuAboutTT;
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.Menu_About_click);
@@ -439,17 +449,9 @@
             // 
             this.menuContextClose.Image = global::OnTopReplica.Properties.Resources.close_new;
             this.menuContextClose.Name = "menuContextClose";
-            this.menuContextClose.Size = new System.Drawing.Size(186, 22);
+            this.menuContextClose.Size = new System.Drawing.Size(194, 22);
             this.menuContextClose.Text = global::OnTopReplica.Strings.MenuClose;
             this.menuContextClose.Click += new System.EventHandler(this.Menu_Close_click);
-            // 
-            // fullOpacityToolStripMenuItem
-            // 
-            this.fullOpacityToolStripMenuItem.DropDown = this.menuOpacity;
-            this.fullOpacityToolStripMenuItem.Image = global::OnTopReplica.Properties.Resources.window_opacity;
-            this.fullOpacityToolStripMenuItem.Name = "fullOpacityToolStripMenuItem";
-            this.fullOpacityToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
-            this.fullOpacityToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuOpacity;
             // 
             // fullSelectWindowToolStripMenuItem
             // 
@@ -459,6 +461,14 @@
             this.fullSelectWindowToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
             this.fullSelectWindowToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuWindows;
             this.fullSelectWindowToolStripMenuItem.ToolTipText = global::OnTopReplica.Strings.MenuWindowsTT;
+            // 
+            // fullOpacityToolStripMenuItem
+            // 
+            this.fullOpacityToolStripMenuItem.DropDown = this.menuOpacity;
+            this.fullOpacityToolStripMenuItem.Image = global::OnTopReplica.Properties.Resources.window_opacity;
+            this.fullOpacityToolStripMenuItem.Name = "fullOpacityToolStripMenuItem";
+            this.fullOpacityToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
+            this.fullOpacityToolStripMenuItem.Text = global::OnTopReplica.Strings.MenuOpacity;
             // 
             // menuFullscreenContext
             // 
@@ -525,7 +535,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Control;
-            this.ClientSize = new System.Drawing.Size(326, 234);
+            this.ClientSize = new System.Drawing.Size(330, 238);
             this.ControlBox = false;
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
             this.HideCaption = true;
@@ -596,6 +606,7 @@
         private System.Windows.Forms.ToolStripMenuItem menuModeStandardToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem menuModeFullscreenToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem menuModeAllScreensToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem restoreToolStripMenuItem;
     }
 }
 

--- a/src/OnTopReplica/MainForm.cs
+++ b/src/OnTopReplica/MainForm.cs
@@ -208,7 +208,15 @@ namespace OnTopReplica {
                 case WM.NCLBUTTONDBLCLK:
                     //Toggle fullscreen mode if double click on caption (whole glass area)
                     if (m.WParam.ToInt32() == HT.CAPTION) {
-                        FullscreenManager.Toggle();
+                        if(!IsRestoreEnabled) {
+                            FullscreenManager.Toggle();
+                        }
+                        else {
+                            if(CurrentThumbnailWindowHandle == null)
+                                return;
+                            Program.Platform.HideForm(this);
+                            Native.WindowManagerMethods.SetForegroundWindow(CurrentThumbnailWindowHandle.Handle);
+                        }
 
                         m.Result = IntPtr.Zero;
                         return;
@@ -456,6 +464,6 @@ namespace OnTopReplica {
         }
 
         #endregion
-        
+
     }
 }

--- a/src/OnTopReplica/MainForm_Features.cs
+++ b/src/OnTopReplica/MainForm_Features.cs
@@ -132,6 +132,19 @@ namespace OnTopReplica {
 
         #endregion
 
+        #region DoubleClickRestore
+
+        private bool _isRestoreEnabled;
+
+        public bool IsRestoreEnabled {
+            get { return _isRestoreEnabled; }
+            set {
+                _isRestoreEnabled = value;
+            }
+        }
+
+        #endregion
+
         #region Position lock
 
         ScreenPosition? _positionLock = null;

--- a/src/OnTopReplica/MainForm_MenuEvents.cs
+++ b/src/OnTopReplica/MainForm_MenuEvents.cs
@@ -22,6 +22,7 @@ namespace OnTopReplica {
             switchToWindowToolStripMenuItem.Enabled = showing;
             resizeToolStripMenuItem.Enabled = showing;
             chromeToolStripMenuItem.Checked = IsChromeVisible;
+            restoreToolStripMenuItem.Checked = IsRestoreEnabled;
             clickForwardingToolStripMenuItem.Checked = ClickForwardingEnabled;
             chromeToolStripMenuItem.Enabled = showing;
             clickThroughToolStripMenuItem.Enabled = showing;
@@ -157,6 +158,10 @@ namespace OnTopReplica {
 
         private void Menu_Chrome_click(object sender, EventArgs e) {
             IsChromeVisible = !IsChromeVisible;
+        }
+
+        private void Menu_Restore_click(object sender, EventArgs e) {
+            IsRestoreEnabled = !IsRestoreEnabled;
         }
 
         private void Menu_Settings_click(object sender, EventArgs e) {

--- a/src/OnTopReplica/Strings.resx
+++ b/src/OnTopReplica/Strings.resx
@@ -670,4 +670,10 @@ OnTopReplica will be closed and the update installed.</value>
   <data name="RegionsY" xml:space="preserve">
     <value>Y</value>
   </data>
+  <data name="MenuRestore" xml:space="preserve">
+    <value>Double-click to restore</value>
+  </data>
+  <data name="MenuRestoreTT" xml:space="preserve">
+    <value>When enabled, double-clicking the replica restores the window instead</value>
+  </data>
 </root>


### PR DESCRIPTION
Added setting to right-click menu that enables switching to source window by double-clicking the replica. Disabled by default.
Wanted this feature myself so I looked into adding it.

Resolves #138

In my original PR, I only manually added a few lines to MainForm.Designer.cs, then saw the snippet about "do not modify in code editor."

Went back and made the changes in the Form Designer, and it generated a lot more changes than I initially intended.

Everything seems functionally the same though.