### PR TITLE
Feature: global hotkey for cycling regions and persistent subregion l…

### DIFF
--- a/src/OnTopReplica/MainForm.cs
+++ b/src/OnTopReplica/MainForm.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using OnTopReplica.Native;
 using OnTopReplica.Properties;
+using OnTopReplica.SidePanels;
 using OnTopReplica.StartupOptions;
 using OnTopReplica.Update;
 using OnTopReplica.WindowSeekers;
@@ -327,8 +328,8 @@ namespace OnTopReplica {
             if (handles.Count == 0)
                 return;
 
-            //At last one thumbnail
-            SetThumbnail(handles[0], null);
+            //At last one thumbnail, preserving any crop selected before enabling group mode.
+            SetThumbnail(handles[0], SelectedThumbnailRegion);
 
             //Handle if no real group
             if (handles.Count == 1)
@@ -370,6 +371,56 @@ namespace OnTopReplica {
 
                 FixPositionAndSize();
             }
+        }
+
+        public bool CycleSavedRegion() {
+            if (!_thumbnailPanel.IsShowingThumbnail)
+                return false;
+
+            var regions = GetSavedRegions();
+            if (regions.Length == 0)
+                return false;
+
+            int nextIndex = 0;
+            var currentRegion = SelectedThumbnailRegion;
+            if (currentRegion != null) {
+                var currentIndex = Array.FindIndex(regions, x => AreRegionsEqual(x.Region, currentRegion));
+                if (currentIndex >= 0)
+                    nextIndex = (currentIndex + 1) % regions.Length;
+            }
+
+            var nextRegion = regions[nextIndex];
+            SelectedThumbnailRegion = nextRegion.Region;
+            _thumbnailPanel.ShowOverlayText(nextRegion.Name);
+
+            if (IsSidePanelOpen && _sidePanelContainer != null && _sidePanelContainer.CurrentSidePanel is RegionPanel) {
+                ((RegionPanel)_sidePanelContainer.CurrentSidePanel).SetRegion(nextRegion);
+            }
+
+            return true;
+        }
+
+        private StoredRegion[] GetSavedRegions() {
+            if (Settings.Default.SavedRegions == null || Settings.Default.SavedRegions.Count == 0)
+                return new StoredRegion[0];
+
+            var regions = new StoredRegion[Settings.Default.SavedRegions.Count];
+            Settings.Default.SavedRegions.CopyTo(regions);
+            Array.Sort(regions, (a, b) => string.Compare(a.Name, b.Name, StringComparison.CurrentCulture));
+
+            return regions;
+        }
+
+        private static bool AreRegionsEqual(ThumbnailRegion left, ThumbnailRegion right) {
+            if (left == null || right == null)
+                return left == right;
+            if (left.Relative != right.Relative)
+                return false;
+
+            if (left.Relative)
+                return left.BoundsAsPadding.Equals(right.BoundsAsPadding);
+
+            return left.Bounds.Equals(right.Bounds);
         }
 
         const int FixMargin = 10;

--- a/src/OnTopReplica/MessagePumpProcessors/GroupSwitchManager.cs
+++ b/src/OnTopReplica/MessagePumpProcessors/GroupSwitchManager.cs
@@ -92,7 +92,7 @@ namespace OnTopReplica.MessagePumpProcessors {
 
             Log.Write("Switched to tracked window: switching to {0} (last use: {1})", next.WindowHandle.Title, next.LastTimeUsed);
 
-            Form.SetThumbnail(next.WindowHandle, null);
+            Form.SetThumbnail(next.WindowHandle, Form.SelectedThumbnailRegion);
         }
 
         protected override void Shutdown() {

--- a/src/OnTopReplica/MessagePumpProcessors/HotKeyManager.cs
+++ b/src/OnTopReplica/MessagePumpProcessors/HotKeyManager.cs
@@ -98,6 +98,7 @@ namespace OnTopReplica.MessagePumpProcessors {
 
             RegisterHandler(Settings.Default.HotKeyCloneCurrent, HotKeyCloneHandler);
             RegisterHandler(Settings.Default.HotKeyShowHide, HotKeyShowHideHandler);
+            RegisterHandler(Settings.Default.HotKeyCycleSavedRegion, HotKeyCycleSavedRegionHandler);
         }
 
         private void RegisterHandler(string spec, HotKeyHandler handler) {
@@ -158,6 +159,13 @@ namespace OnTopReplica.MessagePumpProcessors {
                 return;
 
             Form.SetThumbnail(handle, null);
+        }
+
+        /// <summary>
+        /// Handles cycling through stored regions on the current thumbnail.
+        /// </summary>
+        void HotKeyCycleSavedRegionHandler() {
+            Form.CycleSavedRegion();
         }
 
         #endregion

--- a/src/OnTopReplica/Properties/Settings.Designer.cs
+++ b/src/OnTopReplica/Properties/Settings.Designer.cs
@@ -228,6 +228,18 @@ namespace OnTopReplica.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("[CTRL]+[SHIFT]+R")]
+        public string HotKeyCycleSavedRegion {
+            get {
+                return ((string)(this["HotKeyCycleSavedRegion"]));
+            }
+            set {
+                this["HotKeyCycleSavedRegion"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Standard")]
         public string FullscreenMode {
             get {

--- a/src/OnTopReplica/Properties/Settings.settings
+++ b/src/OnTopReplica/Properties/Settings.settings
@@ -53,6 +53,9 @@
     <Setting Name="HotKeyShowHide" Type="System.String" Scope="User">
       <Value Profile="(Default)">[CTRL]+[SHIFT]+O</Value>
     </Setting>
+    <Setting Name="HotKeyCycleSavedRegion" Type="System.String" Scope="User">
+      <Value Profile="(Default)">[CTRL]+[SHIFT]+R</Value>
+    </Setting>
     <Setting Name="FullscreenMode" Type="System.String" Scope="User">
       <Value Profile="(Default)">Standard</Value>
     </Setting>

--- a/src/OnTopReplica/SidePanels/OptionsPanel.Designer.cs
+++ b/src/OnTopReplica/SidePanels/OptionsPanel.Designer.cs
@@ -27,6 +27,8 @@
             this.panelMain = new System.Windows.Forms.Panel();
             this.groupHotkeys = new System.Windows.Forms.GroupBox();
             this.label1 = new System.Windows.Forms.Label();
+            this.lblHotKeyCycleRegion = new System.Windows.Forms.Label();
+            this.txtHotKeyCycleRegion = new OnTopReplica.HotKeyTextBox();
             this.lblHotKeyShowHide = new System.Windows.Forms.Label();
             this.txtHotKeyShowHide = new OnTopReplica.HotKeyTextBox();
             this.lblHotKeyClone = new System.Windows.Forms.Label();
@@ -42,7 +44,7 @@
             // btnClose
             // 
             this.btnClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnClose.Location = new System.Drawing.Point(220, 243);
+            this.btnClose.Location = new System.Drawing.Point(220, 273);
             this.btnClose.Name = "btnClose";
             this.btnClose.Size = new System.Drawing.Size(87, 27);
             this.btnClose.TabIndex = 0;
@@ -60,7 +62,7 @@
             this.panelMain.Controls.Add(this.groupLanguage);
             this.panelMain.Location = new System.Drawing.Point(7, 7);
             this.panelMain.Name = "panelMain";
-            this.panelMain.Size = new System.Drawing.Size(301, 230);
+            this.panelMain.Size = new System.Drawing.Size(301, 260);
             this.panelMain.TabIndex = 1;
             // 
             // groupHotkeys
@@ -68,13 +70,15 @@
             this.groupHotkeys.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupHotkeys.Controls.Add(this.label1);
+            this.groupHotkeys.Controls.Add(this.lblHotKeyCycleRegion);
+            this.groupHotkeys.Controls.Add(this.txtHotKeyCycleRegion);
             this.groupHotkeys.Controls.Add(this.lblHotKeyShowHide);
             this.groupHotkeys.Controls.Add(this.txtHotKeyShowHide);
             this.groupHotkeys.Controls.Add(this.lblHotKeyClone);
             this.groupHotkeys.Controls.Add(this.txtHotKeyClone);
             this.groupHotkeys.Location = new System.Drawing.Point(3, 89);
             this.groupHotkeys.Name = "groupHotkeys";
-            this.groupHotkeys.Size = new System.Drawing.Size(294, 130);
+            this.groupHotkeys.Size = new System.Drawing.Size(294, 160);
             this.groupHotkeys.TabIndex = 1;
             this.groupHotkeys.TabStop = false;
             this.groupHotkeys.Text = "Hot keys:";
@@ -83,11 +87,31 @@
             // 
             this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.Location = new System.Drawing.Point(7, 78);
+            this.label1.Location = new System.Drawing.Point(7, 108);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(182, 50);
-            this.label1.TabIndex = 4;
+            this.label1.Size = new System.Drawing.Size(280, 42);
+            this.label1.TabIndex = 6;
             this.label1.Text = "These system-wide shortcuts can also be used when OnTopReplica is not in focus.";
+            // 
+            // lblHotKeyCycleRegion
+            // 
+            this.lblHotKeyCycleRegion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblHotKeyCycleRegion.BackColor = System.Drawing.Color.Transparent;
+            this.lblHotKeyCycleRegion.Location = new System.Drawing.Point(196, 85);
+            this.lblHotKeyCycleRegion.Name = "lblHotKeyCycleRegion";
+            this.lblHotKeyCycleRegion.Size = new System.Drawing.Size(91, 33);
+            this.lblHotKeyCycleRegion.TabIndex = 5;
+            this.lblHotKeyCycleRegion.Text = "Cycle regions";
+            // 
+            // txtHotKeyCycleRegion
+            // 
+            this.txtHotKeyCycleRegion.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtHotKeyCycleRegion.Location = new System.Drawing.Point(7, 82);
+            this.txtHotKeyCycleRegion.Name = "txtHotKeyCycleRegion";
+            this.txtHotKeyCycleRegion.ReadOnly = true;
+            this.txtHotKeyCycleRegion.Size = new System.Drawing.Size(181, 23);
+            this.txtHotKeyCycleRegion.TabIndex = 4;
             // 
             // lblHotKeyShowHide
             // 
@@ -173,10 +197,10 @@
             this.AutoScroll = true;
             this.Controls.Add(this.panelMain);
             this.Controls.Add(this.btnClose);
-            this.MinimumSize = new System.Drawing.Size(315, 277);
+            this.MinimumSize = new System.Drawing.Size(315, 307);
             this.Name = "OptionsPanel";
             this.Padding = new System.Windows.Forms.Padding(7, 7, 7, 7);
-            this.Size = new System.Drawing.Size(315, 277);
+            this.Size = new System.Drawing.Size(315, 307);
             this.panelMain.ResumeLayout(false);
             this.groupHotkeys.ResumeLayout(false);
             this.groupHotkeys.PerformLayout();
@@ -197,6 +221,8 @@
         private System.Windows.Forms.Label lblHotKeyShowHide;
         private HotKeyTextBox txtHotKeyShowHide;
         private System.Windows.Forms.Label lblHotKeyClone;
+        private System.Windows.Forms.Label lblHotKeyCycleRegion;
+        private HotKeyTextBox txtHotKeyCycleRegion;
         private System.Windows.Forms.Label label1;
     }
 }

--- a/src/OnTopReplica/SidePanels/OptionsPanel.cs
+++ b/src/OnTopReplica/SidePanels/OptionsPanel.cs
@@ -23,6 +23,7 @@ namespace OnTopReplica.SidePanels {
             groupHotkeys.Text = Strings.SettingsHotKeyTitle;
             lblHotKeyShowHide.Text = Strings.SettingsHotKeyShowHide;
             lblHotKeyClone.Text = Strings.SettingsHotKeyClone;
+            lblHotKeyCycleRegion.Text = Strings.SettingsHotKeyCycleRegion;
             label1.Text = Strings.SettingsHotKeyDescription;
 
             btnClose.Text = Strings.MenuClose;
@@ -37,6 +38,7 @@ namespace OnTopReplica.SidePanels {
             form.MessagePumpManager.Get<OnTopReplica.MessagePumpProcessors.HotKeyManager>().Enabled = false;
             txtHotKeyShowHide.Text = Settings.Default.HotKeyShowHide;
             txtHotKeyClone.Text = Settings.Default.HotKeyCloneCurrent;
+            txtHotKeyCycleRegion.Text = Settings.Default.HotKeyCycleSavedRegion;
         }
 
         private void Close_click(object sender, EventArgs e) {
@@ -55,6 +57,7 @@ namespace OnTopReplica.SidePanels {
             //Update hotkey settings and update processor
             Settings.Default.HotKeyShowHide = txtHotKeyShowHide.Text;
             Settings.Default.HotKeyCloneCurrent = txtHotKeyClone.Text;
+            Settings.Default.HotKeyCycleSavedRegion = txtHotKeyCycleRegion.Text;
             var manager = form.MessagePumpManager.Get<OnTopReplica.MessagePumpProcessors.HotKeyManager>();
             manager.RefreshHotkeys();
             manager.Enabled = true;

--- a/src/OnTopReplica/Strings.Designer.cs
+++ b/src/OnTopReplica/Strings.Designer.cs
@@ -1474,6 +1474,15 @@ namespace OnTopReplica {
         }
         
         /// <summary>
+        ///   查詢類似 Cycle saved region 的當地語系化字串。
+        /// </summary>
+        internal static string SettingsHotKeyCycleRegion {
+            get {
+                return ResourceManager.GetString("SettingsHotKeyCycleRegion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查詢類似 Hot keys: 的當地語系化字串。
         /// </summary>
         internal static string SettingsHotKeyTitle {

--- a/src/OnTopReplica/Strings.resx
+++ b/src/OnTopReplica/Strings.resx
@@ -585,6 +585,9 @@ You can enable click-through later</value>
   <data name="SettingsHotKeyShowHide" xml:space="preserve">
     <value>Show/Hide</value>
   </data>
+  <data name="SettingsHotKeyCycleRegion" xml:space="preserve">
+    <value>Cycle regions</value>
+  </data>
   <data name="SettingsHotKeyTitle" xml:space="preserve">
     <value>Hot keys:</value>
   </data>

--- a/src/OnTopReplica/ThumbnailPanel.cs
+++ b/src/OnTopReplica/ThumbnailPanel.cs
@@ -16,6 +16,8 @@ namespace OnTopReplica {
 
         //Labels
         WindowsFormsAero.ThemeLabel _labelGlass;
+        readonly Timer _overlayTimer = new Timer();
+        string _overlayText;
 
         public ThumbnailPanel() {
             InitFormComponents();
@@ -36,6 +38,15 @@ namespace OnTopReplica {
                 TextAlignVertical = VerticalAlignment.Center
             };
             this.Controls.Add(_labelGlass);
+
+            _overlayTimer.Interval = 1200;
+            _overlayTimer.Tick += OverlayTimer_Tick;
+        }
+
+        void OverlayTimer_Tick(object sender, EventArgs e) {
+            _overlayTimer.Stop();
+            _overlayText = null;
+            Invalidate();
         }
 
         #region Properties and settings
@@ -240,7 +251,19 @@ namespace OnTopReplica {
             }
 
             _thumbnail = null;
+            _overlayTimer.Stop();
+            _overlayText = null;
             _labelGlass.Visible = true;
+        }
+
+        public void ShowOverlayText(string text) {
+            _overlayText = text;
+            _overlayTimer.Stop();
+
+            if (!string.IsNullOrEmpty(text))
+                _overlayTimer.Start();
+
+            Invalidate();
         }
 
         /// <summary>
@@ -422,6 +445,25 @@ namespace OnTopReplica {
                 //Show cursor coordinates
                 e.Graphics.DrawLine(RedPen, new Point(0, _regionLastPoint.Y), new Point(ClientSize.Width, _regionLastPoint.Y));
                 e.Graphics.DrawLine(RedPen, new Point(_regionLastPoint.X, 0), new Point(_regionLastPoint.X, ClientSize.Height));
+            }
+
+            if (!string.IsNullOrEmpty(_overlayText)) {
+                var flags = TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter |
+                    TextFormatFlags.EndEllipsis | TextFormatFlags.SingleLine;
+                var maxWidth = Math.Max(80, ClientSize.Width - 24);
+                var textSize = TextRenderer.MeasureText(e.Graphics, _overlayText, Font, new Size(maxWidth, 0), flags);
+                var overlayBounds = new Rectangle(
+                    Math.Max(8, (ClientSize.Width - textSize.Width) / 2 - 10),
+                    8,
+                    Math.Min(maxWidth, textSize.Width + 20),
+                    textSize.Height + 12
+                );
+
+                using (var background = new SolidBrush(Color.FromArgb(180, Color.Black))) {
+                    e.Graphics.FillRectangle(background, overlayBounds);
+                }
+
+                TextRenderer.DrawText(e.Graphics, _overlayText, Font, overlayBounds, Color.White, flags);
             }
 
             base.OnPaint(e);

--- a/src/OnTopReplica/ThumbnailRegion.cs
+++ b/src/OnTopReplica/ThumbnailRegion.cs
@@ -150,11 +150,15 @@ namespace OnTopReplica {
                 ret = _bounds;
             }
 
-            //Constrain to bounds
-            if (ret.X + ret.Width > sourceSize.Width)
-                ret.Width = sourceSize.Width - ret.X;
-            if (ret.Y + ret.Height > sourceSize.Height)
-                ret.Height = sourceSize.Height - ret.Y;
+            //Constrain to bounds. This keeps saved/group-switched regions valid
+            // even when the next source window is smaller than the original one.
+            ret.Width = Math.Min(Math.Max(MinimumRegionSize, ret.Width), sourceSize.Width);
+            ret.Height = Math.Min(Math.Max(MinimumRegionSize, ret.Height), sourceSize.Height);
+
+            if (ret.X < 0 || ret.X + ret.Width > sourceSize.Width)
+                ret.X = Math.Max(0, (sourceSize.Width - ret.Width) / 2);
+            if (ret.Y < 0 || ret.Y + ret.Height > sourceSize.Height)
+                ret.Y = Math.Max(0, (sourceSize.Height - ret.Height) / 2);
 
             return ret;
         }

--- a/src/OnTopReplica/app.config
+++ b/src/OnTopReplica/app.config
@@ -56,6 +56,9 @@
        <setting name="HotKeyShowHide" serializeAs="String">
         <value>[CTRL]+[SHIFT]+O</value>
        </setting>
+       <setting name="HotKeyCycleSavedRegion" serializeAs="String">
+        <value>[CTRL]+[SHIFT]+R</value>
+       </setting>
        <setting name="FullscreenMode" serializeAs="String">
         <value>Standard</value>
        </setting>


### PR DESCRIPTION
🚀 NEW Custom Features (added in this fork):

> 🌟 **Feature 1: Global Hotkey for Cycling Through Stored Regions** > *Quickly switch between your saved regions (crops) using a global hotkey (Default: `Ctrl+Shift+R`). No more context menu digging.*

> 🌟 **Feature 2: Uniform Region Locking for Group Switching Mode** > *When cycling through a group of windows, the replica now maintains the same selected subregion for all windows in the group, ensuring a consistent view.*

---

Forked version: https://github.com/ghscryderepo/OnTopReplica